### PR TITLE
Fix names in simp config answers file, clean up

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure('2') do |c|
   server_post_up = <<-EOS.gsub(/^[[:blank:]]{4}/, '')
     Now run the following commands to get going:
 
-        simp config -a /vagrant/answers.yaml
+        simp config -a /vagrant/simp_config_answers.yaml
         simp bootstrap
         ldapadd -Z -x -D 'cn=LDAPAdmin,ou=People,dc=simp,dc=test' -w 'NjUfdMTAKUMRdNNDXcfTVvrKJTgY8uZQ' -f /var/local/simp/files/add_user_with_password.ldif
 

--- a/simp_config_answers.yaml
+++ b/simp_config_answers.yaml
@@ -1,15 +1,3 @@
-#=======================================
-# simp config answers
-#
-# generated on 2016-03-04 16:09:18 +0000
-#---------------------------------------
-# you can use these answers to quickly configure subsequent simp installations
-# by running the command:
-#
-#   simp config -a /PATH/TO/THIS/FILE
-#
-# simp config will prompt for any missing items
-#=======================================
 ---
 # === use_fips ===
 # Enable FIPS mode on this system.
@@ -25,31 +13,31 @@ use_fips: true
 
 # === network::interface ===
 # The network interface to use to connect to the network.
-"network::interface": enp0s3
+network::interface: 'enp0s3'
 
 # === network::setup_nic ===
 # Do you want to activate this NIC now?
-"network::setup_nic": true
+network::setup_nic: true
 
 # === dhcp ===
 # Whether or not to use DHCP to set up your network ("static" or "dhcp")
-dhcp: static
+dhcp: 'static'
 
 # === hostname ===
 # The FQDN of the system.
-hostname: puppet.test.net
+hostname: 'server01.simp.test'
 
 # === ipaddress ===
 # The IP address of this system
-ipaddress: "10.0.2.15"
+ipaddress: '10.0.2.15'
 
 # === netmask ===
 # The netmask of the system.
-netmask: "255.255.255.0"
+netmask: '255.255.255.0'
 
 # === gateway ===
 # The default gateway.
-gateway: "10.0.2.2"
+gateway: '10.0.2.2'
 
 # === dns::servers ===
 # A list of DNS servers for the managed hosts.
@@ -66,24 +54,22 @@ gateway: "10.0.2.2"
 # convert your system to a caching DNS server. You'll know
 # that you have this situation if you end up with a duplicate
 # definition for File['/etc/named.conf'].
-"dns::servers":
-  - "192.168.33.10"
-  - "10.0.2.3"
-  - "8.8.8.8"
+dns::servers:
+  - '192.168.33.10'
 
 # === dns::search ===
 # The DNS domain search string.
 # Remember to put these in the appropriate order for your environment!
-"dns::search":
-  - test.net
+dns::search:
+  - 'simp.test'
 
 # === client_nets ===
 # A list of client networks for your systems, in CIDR notation.
 # If you need this to be more (or less) restrictive for a given class,
 # you can override it in Hiera.
 client_nets:
-  - "10.0.2.0/24"
-  - "192.168.33.10/16"
+  - '10.0.2.0/24'
+  - '192.168.33.10/16'
 
 # === ntpd::servers ===
 # Your network's NTP time servers.
@@ -91,14 +77,16 @@ client_nets:
 # A consistent time source is critical to your systems' security.
 # DO NOT run multiple production systems using individual hardware clocks!
 # For many networks, the default gateway (10.0.2.2) provides an NTP server.
-"ntpd::servers":
-  - "0.pool.ntp.org"
-  - "1.pool.ntp.org"
+ntpd::servers:
+  - '0.us.pool.ntp.org'
+  - '1.us.pool.ntp.org'
+  - '2.us.pool.ntp.org'
+  - '3.us.pool.ntp.org'
 
 # === log_servers ===
 # Your log server(s). Only use hostnames here if at all possible.
 log_servers:
-  - puppet.test.net
+  - 'server01.simp.test'
 
 # === failover_log_servers ===
 # Failover log server(s) in case your log servers(s) fail.
@@ -106,7 +94,7 @@ failover_log_servers: []
 
 # === simp::yum::servers ===
 # Your SIMP yum server(s).
-"simp::yum::servers":
+simp::yum::servers:
   - "%{hiera('puppet::server')}"
 
 # === use_auditd ===
@@ -122,7 +110,7 @@ use_iptables: true
 
 # === simplib::runlevel ===
 # The default system runlevel (1-5).
-"simplib::runlevel": "3"
+simplib::runlevel: 3
 
 # === selinux::ensure ===
 # SELinux is good.
@@ -130,7 +118,7 @@ use_iptables: true
 # Not all modules are compatible with SELinux in enforcing mode but the core
 # SIMP modules are. You should not take this below 'permissive' unless it is
 # truly necessary.
-"selinux::ensure": enforcing
+selinux::ensure: 'enforcing'
 
 # === set_grub_password ===
 # Whether or not to set the GRUB password on this system.
@@ -138,7 +126,11 @@ set_grub_password: true
 
 # === grub::password ===
 # The password to access GRUB
-"grub::password": grub.pbkdf2.sha512.10000.6198CB1A846FEBEA1519255F0FE7C555A864DD17DE768197F87272E2DF05308A4ED677EB69F1FBA057B432F108E06C5BF35F5A52CA16F614D022993793590384.915D0C2348D096FC42D280E44A97804D3C4652664150FB7714C217BDF6D3027378A8D9EB3D22B938D13269E2B9A20601FB2AAB34615D2E96D0143AABF9C756C3
+grub::password: "\
+  grub.pbkdf2.sha512.10000.6198CB1A846FEBEA1519255F0FE7C555A864DD17DE7681\
+  97F87272E2DF05308A4ED677EB69F1FBA057B432F108E06C5BF35F5A52CA16F614D0229\
+  93793590384.915D0C2348D096FC42D280E44A97804D3C4652664150FB7714C217BDF6D\
+  3027378A8D9EB3D22B938D13269E2B9A20601FB2AAB34615D2E96D0143AABF9C756C3"
 
 # === is_master_yum_server ===
 # Is the master also used as a YUM server?
@@ -150,28 +142,28 @@ is_master_yum_server: true
 
 # === puppet::server ===
 # The Hostname or FQDN of the puppet server.
-"puppet::server": puppet.test.net
+puppet::server: 'server01.simp.test'
 
 # === puppet::server::ip ===
 # The Puppet server's IP address.
 # This is used to configure /etc/hosts properly.
-"puppet::server::ip": "192.168.33.10"
+puppet::server::ip: '192.168.33.10'
 
 # === puppet::ca ===
 # The Puppet Certificate Authority
-"puppet::ca": puppet.test.net
+puppet::ca: server01.simp.test
 
 # === puppet::ca_port ===
 # The port which the Puppet CA will listen on (8141 by default).
-"puppet::ca_port": 8141
+puppet::ca_port: 8141
 
 # === puppetdb::master::config::puppetdb_server ===
 # The dns name or ip of the puppetdb server
-"puppetdb::master::config::puppetdb_server": "%{hiera('puppet::server')}"
+puppetdb::master::config::puppetdb_server: "%{hiera('puppet::server')}"
 
 # === puppetdb::master::config::puppetdb_port ===
 # The PuppetDB server port number
-"puppetdb::master::config::puppetdb_port": "8139"
+puppetdb::master::config::puppetdb_port: '8139'
 
 # === use_ldap ===
 # Whether or not to use LDAP on this system.
@@ -180,58 +172,58 @@ use_ldap: true
 
 # === ldap::base_dn ===
 # The Base DN of the LDAP server
-"ldap::base_dn": "dc=test,dc=net"
+ldap::base_dn: 'dc=simp,dc=test'
 
 # === ldap::bind_dn ===
 # LDAP Bind Distinguished Name
-"ldap::bind_dn": "cn=hostAuth,ou=Hosts,%{hiera('ldap::base_dn')}"
+ldap::bind_dn: "cn=hostAuth,ou=Hosts,%{hiera('ldap::base_dn')}"
 
 # === ldap::bind_pw ===
 # The LDAP bind password
-"ldap::bind_pw": "CU0%d%7xRYFJcI9yt7nr*0BUZ8IHg&eo"
+ldap::bind_pw: 'CU0%d%7xRYFJcI9yt7nr*0BUZ8IHg&eo'
 
 # === ldap::bind_hash ===
 # The salted LDAP bind password hash
-"ldap::bind_hash": "{SSHA}DNbi/hqU/OT8vvkcprSrYwUjrlaBq9H3"
+ldap::bind_hash: '{SSHA}DNbi/hqU/OT8vvkcprSrYwUjrlaBq9H3'
 
 # === ldap::sync_dn ===
 #
-"ldap::sync_dn": "cn=LDAPSync,ou=Hosts,%{hiera('ldap::base_dn')}"
+ldap::sync_dn: "cn=LDAPSync,ou=Hosts,%{hiera('ldap::base_dn')}"
 
 # === ldap::sync_pw ===
 # The LDAP sync password
-"ldap::sync_pw": "pwJORySZfSg+Ftwb9EmMRC&ql1f7PU*N"
+ldap::sync_pw: 'pwJORySZfSg+Ftwb9EmMRC&ql1f7PU*N'
 
 # === ldap::sync_hash ===
 #
-"ldap::sync_hash": "{SSHA}TiIgrvOOVW2x0lntQQkePVYkjoleCSvQ"
+ldap::sync_hash: '{SSHA}TiIgrvOOVW2x0lntQQkePVYkjoleCSvQ'
 
 # === ldap::root_dn ===
 # The LDAP root DN.
-"ldap::root_dn": "cn=LDAPAdmin,ou=People,%{hiera('ldap::base_dn')}"
+ldap::root_dn: "cn=LDAPAdmin,ou=People,%{hiera('ldap::base_dn')}"
 
 # === ldap::root_hash ===
 # The LDAP root password hash.
 #  If you set this with simp config, type the password and the hash will be
 # generated for you.'
-"ldap::root_hash": "{SSHA}M0ahDM2+42wqvexRx5vHYgR5gl0+ekMY"
+ldap::root_hash: '{SSHA}M0ahDM2+42wqvexRx5vHYgR5gl0+ekMY'
 
 # === ldap::master ===
 # This is the LDAP master in URI form (ldap://server)
-"ldap::master": "ldap://puppet.test.net"
+ldap::master: 'ldap://server01.simp.test'
 
 # === ldap::uri ===
 # List of OpenLDAP servers in URI form (ldap://server)
-"ldap::uri":
-  - "ldap://puppet.test.net"
+ldap::uri:
+  - 'ldap://server01.simp.test'
 
 # === sssd::domains ===
 # A list of domains for SSSD to use.
 # `simp config` will automativcally populate this field with `FQDN` if
 # `use_fqdn` is true, otherwise it will comment out the field.
 #
-"sssd::domains":
-  - LDAP
+sssd::domains:
+  - 'LDAP'
 
 # === rsync::base ===
 # Several modules use rsync as a means of pulling down large
@@ -240,13 +232,12 @@ use_ldap: true
 #
 # Individual modules can be overridden as required.
 #
-"rsync::base": "/var/simp/rsync/%{::operatingsystem}/%{::lsbmajdistrelease}"
+rsync::base: "/var/simp/rsync/%{::operatingsystem}/%{::lsbmajdistrelease}"
 
 # === rsync::server ===
 # rsync server (usually the primary puppet master)
-"rsync::server": "127.0.0.1"
+rsync::server: '127.0.0.1'
 
 # === rsync::timeout ===
 # maximum rsync timeout in seconds.  0 = no timeout
-"rsync::timeout": "1"
-
+rsync::timeout: '1'


### PR DESCRIPTION
This fixes the server hostname in the `simp config` answers file.  It
also cleans up the file for readability and renames it using a more
verbose, obvious name.
